### PR TITLE
Add mpd_allowed_sites filter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# Editor-specific #
+###################
+.vscode/
+
 # Compiled source #
 ###################
 *.com

--- a/addons/bulkaction-mpd-addon.php
+++ b/addons/bulkaction-mpd-addon.php
@@ -43,7 +43,7 @@ function mpd_bulk_admin_script() {
 
     if( is_multisite() ){
         $defaultoptions = mdp_get_default_options();
-        $sites          = mpd_wp_get_sites();
+        $allowed_sites  = mpd_get_allowed_sites();
         $options        = get_option('mdp_settings');
         $post_status    = isset($_REQUEST["post_status"]) ? $_REQUEST["post_status"] : '';
 
@@ -57,16 +57,12 @@ function mpd_bulk_admin_script() {
 
               jQuery(document).ready(function() {
 
-                <?php foreach ($sites as $site) :?>
+                <?php foreach ($allowed_sites as $site) :?>
 
                   <?php $blog_details = get_blog_details($site->blog_id); ?> 
 
-                    <?php if($site->blog_id != get_current_blog_id() && current_user_can_for_blog($site->blog_id, mpd_get_required_cap())):?> 
-
-                      jQuery('<option>').val("dup-<?php echo $site->blog_id ?>").text('<?php _e('Duplicate to ')?><?php echo $blog_details->blogname; ?>').appendTo("select[name='action']");
-                      jQuery('<option>').val("dup-<?php echo $site->blog_id ?>").text('<?php _e('Duplicate to ')?><?php echo $blog_details->blogname; ?>').appendTo("select[name='action2']");
-
-                    <?php endif; ?>
+                    jQuery('<option>').val("dup-<?php echo $site->blog_id ?>").text('<?php _e('Duplicate to ')?><?php echo $blog_details->blogname; ?>').appendTo("select[name='action']");
+                    jQuery('<option>').val("dup-<?php echo $site->blog_id ?>").text('<?php _e('Duplicate to ')?><?php echo $blog_details->blogname; ?>').appendTo("select[name='action2']");
                     
                   <?php endforeach; ?>
 

--- a/addons/restrictSites-mpd-addon.php
+++ b/addons/restrictSites-mpd-addon.php
@@ -45,15 +45,15 @@ function restrict_option_setting_render(){
 		<div class="mdp-inputcontainer">
 			<input type="radio" class="mdp_radio" name='mdp_settings[restrict_option_setting]' id="mpd_restrict_none" <?php checked($mdp_restrict_radio_label_value, 'none'); ?> value="none">
 		
-			<label class="mdp_radio_label" for="radio-choice-1"><?php _e('No Restrictions', 'multisite-post-duplicator' ) ?></label>
+			<label class="mdp_radio_label" for="mpd_restrict_none"><?php _e('No Restrictions', 'multisite-post-duplicator' ) ?></label>
 			    
 			<input type="radio" class="mdp_radio" name='mdp_settings[restrict_option_setting]' id="mpd_restrict_some" <?php checked($mdp_restrict_radio_label_value, 'some'); ?> value="some">
 		
-			<label class="mdp_radio_label" for="radio-choice-2"><?php _e('Restrict Some Sites', 'multisite-post-duplicator' ) ?></label>
+			<label class="mdp_radio_label" for="mpd_restrict_some"><?php _e('Restrict Some Sites', 'multisite-post-duplicator' ) ?></label>
 		
 			<input type="radio" class="mdp_radio" name='mdp_settings[restrict_option_setting]' id="mpd_restrict_set_master" <?php checked($mdp_restrict_radio_label_value, 'master'); ?> value="master">
 		
-			<label class="mdp_radio_label" for="radio-choice-3"><?php _e('Select a Master Site', 'multisite-post-duplicator') ?></label>
+			<label class="mdp_radio_label" for="mpd_restrict_set_master"><?php _e('Select a Master Site', 'multisite-post-duplicator') ?></label>
 			
 			<?php mpd_information_icon('You can, if you want, limit MPD functionality to only certain sites.'); ?>
 			
@@ -64,6 +64,18 @@ function restrict_option_setting_render(){
   <?php
 
 }
+
+function mpd_filter_restricted_sites($sites) {
+
+	$restricted_ids = mpd_get_restrict_some_sites_options();
+
+	return array_filter($sites, function($site) use ($restricted_ids) {
+
+		return !in_array($site->blog_id, $restricted_ids);
+	});
+}
+add_filter('mpd_allowed_sites', 'mpd_filter_restricted_sites');
+
 /**
  * @ignore
  */

--- a/inc/mpd-functions.php
+++ b/inc/mpd-functions.php
@@ -848,6 +848,21 @@ function mpd_settings_field($tag, $settings_title, $callback_function_to_markup,
 
 }
 
+function mpd_get_allowed_sites() {
+
+    $sites = mpd_wp_get_sites();
+
+    $current_blog_id = get_current_blog_id();
+
+    $valid_sites = array_filter($sites, function($site) {
+
+        return $site->blog_id != $current_blog_id
+               && current_user_can_for_blog($site->blog_id, mpd_get_required_cap());
+    });
+
+    return apply_filters('mpd_allowed_sites', $valid_sites);
+}
+
 /**
  * This function allows for hooking into the sites returned in the WP core wp_get_sites() function.
  *

--- a/inc/mpd-functions.php
+++ b/inc/mpd-functions.php
@@ -854,7 +854,7 @@ function mpd_get_allowed_sites() {
 
     $current_blog_id = get_current_blog_id();
 
-    $valid_sites = array_filter($sites, function($site) {
+    $valid_sites = array_filter($sites, function($site) use ($current_blog_id) {
 
         return $site->blog_id != $current_blog_id
                && current_user_can_for_blog($site->blog_id, mpd_get_required_cap());

--- a/inc/persist.php
+++ b/inc/persist.php
@@ -402,7 +402,7 @@ function persist_option_setting_render(){
  */
 function persist_functionality_setting_render(){
   
-  $options = get_option( 'mdp_settings' ); ?>
+  $options = get_option( 'mdp_settings' ) || mdp_get_default_options(); ?>
 
  	<div class="checkbox checkbox-slider--b-flat">
 		

--- a/inc/postform_ui.php
+++ b/inc/postform_ui.php
@@ -155,7 +155,7 @@ add_action('mpd_before_metabox_content', 'mpd_metabox_prefix', 10);
 */
 function mpd_do_metabox_site_list(){
 
-    $sites = mpd_wp_get_sites();
+    $allowed_sites = mpd_get_allowed_sites();
 
     ?>
     <script>
@@ -184,41 +184,37 @@ function mpd_do_metabox_site_list(){
 
             <?php $current_blog_id = get_current_blog_id(); ?>
 
-            <?php foreach ($sites as $site): ?>
+            <?php foreach ($allowed_sites as $site): ?>
 
-                <?php if (current_user_can_for_blog($site->blog_id, mpd_get_required_cap()) && !in_array($site->blog_id, mpd_get_restrict_some_sites_options())) : ?>
+                <?php $blog_details = get_blog_details($site->blog_id); ?>
 
-                    <?php $blog_details = get_blog_details($site->blog_id); ?>
+                <li id="mpd_blog_<?php echo $site->blog_id; ?>" class="mpd-site-checkbox">
 
-                    <li id="mpd_blog_<?php echo $site->blog_id; ?>" class="mpd-site-checkbox">
+                    <label class="selectit">
 
-                        <label class="selectit">
+                        <input
 
-                            <input
+                            class="<?php echo $site->blog_id == $current_blog_id ? 'mpd-current-site' : '';?>"
 
-                                class="<?php echo $site->blog_id == $current_blog_id ? 'mpd-current-site' : '';?>"
+                            value="<?php echo $site->blog_id; ?>"
 
-                                value="<?php echo $site->blog_id; ?>"
+                            type="checkbox"
 
-                                type="checkbox"
+                            name="mpd_blogs[]"
 
-                                name="mpd_blogs[]"
+                            id="in_blog_<?php echo $site->blog_id; ?>">
 
-                                id="in_blog_<?php echo $site->blog_id; ?>">
+                            <?php
 
-                                <?php
+                                echo $site->blog_id == $current_blog_id ? '<em>' : '';
+                                echo $blog_details->blogname . " ";
+                                echo $site->blog_id == $current_blog_id ? ' <small>(' . __('Current Site', 'multisite-post-duplicator' ) . ')</small></em>' : '';
 
-                                    echo $site->blog_id == $current_blog_id ? '<em>' : '';
-                                    echo $blog_details->blogname . " ";
-                                    echo $site->blog_id == $current_blog_id ? ' <small>(' . __('Current Site', 'multisite-post-duplicator' ) . ')</small></em>' : '';
+                            ?>
 
-                                ?>
+                    </label>
 
-                        </label>
-
-                    </li>
-
-                <?php endif; ?>
+                </li>
 
             <?php endforeach; ?>
 


### PR DESCRIPTION
Add the mpd_allowed_sites filter. Existing behavior should be preserved exactly as is. I use this hook in a new addon which allows to whitelist a list of sites which can be shared to instead of blacklisting them individually like the restrictSites addon does. My plugin's code is available here: https://github.com/SharkMediaSport/multisite-post-duplicator-whitelist/